### PR TITLE
bugfix/#30341/corrigir-exibicao-campo-cep-mobile

### DIFF
--- a/checkout.css
+++ b/checkout.css
@@ -1714,4 +1714,8 @@ span[data-bind*="text: availableLabel"] {
   .cart-more-options #shipping-preview-container {
       display: block !important;
   }
+
+  .cart-more-options .cart-select-gift-placeholder:empty {
+    display: none !important;
+  }
 }

--- a/checkout.css
+++ b/checkout.css
@@ -1709,3 +1709,9 @@ span[data-bind*="text: availableLabel"] {
 .payment-discounts-list tbody td.code {
   display: none;
 }
+
+@media (max-width: 690px) {
+  .cart-more-options #shipping-preview-container {
+      display: block !important;
+  }
+}


### PR DESCRIPTION
@williamcms esta PR resolve o problema de campo de CEP que não está exibido checkout em mobile.

[Print do bug](https://prnt.sc/wYMfKAdEA4yu)
[Print do problema solucionado](https://prnt.sc/lKKLVozHFtAR)

Por alguma razão havia uma classe escondendo o container responsável pela exibição do CEP em dispositivos móveis. Busquei dentro do repositório e também no script do painel e não encontrei nenhum indício de declaração desta ação, o que me leva a crer que é algo nativo do checkout da VTEX.
[Print da classe desativando o container de cep](https://prnt.sc/yNIxj8QS1Ic6)